### PR TITLE
change docker base image from scratch to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as prep
+FROM alpine:3.19 as prep
 RUN apk --update add ca-certificates
 
 RUN mkdir -p /tmp
@@ -10,7 +10,8 @@ ARG TARGETOS
 ARG TARGETARCH
 COPY ./cmd/otelcontribcol_${TARGETOS}_${TARGETARCH} /otelcol-contrib
 
-FROM scratch
+#FROM scratch
+FROM alpine:3.19
 
 ARG USER_UID=10001
 USER ${USER_UID}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

based https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/fileexporter, 

> The official [opentelemetry-collector-contrib container](https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags#!) does not have a writable filesystem by default since it's built on the scratch layer. As such, you will need to create a writable directory for the path, potentially by mounting writable volumes or creating a custom image.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>